### PR TITLE
Null object from dictionary fix

### DIFF
--- a/GeoReporter/GeoReporter/Controllers/ViewRequestController.m
+++ b/GeoReporter/GeoReporter/Controllers/ViewRequestController.m
@@ -111,7 +111,25 @@ static CGFloat    const kMediaCellHeight = 122;
     if (section == 0) {
         NSDictionary *sr = _report.serviceRequest;
         NSDictionary *post = _report.postData;
-        return (sr && sr[kOpen311_Description]) ? sr[kOpen311_Description] : post[kOpen311_Description];
+        
+        NSString *titleForHeader = nil;
+        
+        if ( sr ) {
+            id srDescription = sr[kOpen311_Description];
+            if ( srDescription != [NSNull null] ) {
+                titleForHeader = srDescription;
+            }
+        }
+        
+        if ( titleForHeader == nil ) {
+            id postDescription = post[kOpen311_Description];
+            if ( postDescription != [NSNull null] ) {
+                titleForHeader = postDescription;
+            }
+        }
+        
+        if ( titleForHeader )
+            return titleForHeader;
     }
     return nil;
 }


### PR DESCRIPTION
Corrects bug where a user submits a report without entering a description of the problem, the app crashes when getting the section header in the titleForHeaderInSection method.

The old code checks to see if the description entry exists in the request dictionary and if it doesn't the code tries to use the description value from the postdata dictionary.

The issue is that if the request dictionary has a description entry that is a NULL object, the current code does does not catch it.  I'm not sure why checking if the entry is nil or exists doesn't work, but the only way I could fix the issue was to compare the id value returned from the dictionary to a NSNULL object.

The code also tried to use the description value from the postData dictionary if the request dictionary was empty.  This is an issue when the description was not submitted because there is not a description key in the postData dictionary.
